### PR TITLE
fix: suppress fallback warning for non-PM commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ This is a Claude Code plugin distributed as a custom marketplace. The repo root 
 4. **Blocks disallowed PMs** using word-boundary regex (not preceded by `[a-zA-Z0-9_.-]`, not followed by `[a-zA-Z0-9_./-]`) to avoid false positives like `pnpm-lock.yaml`, `.npm/`, `npm-check`
 5. **Outputs hook JSON** with one of three outcomes:
    - `deny` decision with reason (blocked PM detected)
-   - `systemMessage` warning (PM could not be detected)
-   - Clean exit with no output (command allowed)
+   - `systemMessage` warning (PM could not be detected AND command contains a PM keyword)
+   - Clean exit with no output (command allowed, or no PM detected and command has no PM keywords)
 
 ## Development
 

--- a/plugins/pm-guard/.claude-plugin/plugin.json
+++ b/plugins/pm-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-guard",
   "description": "Never accidentally npm install in a pnpm project again — guards npm, yarn, pnpm, bun, and deno.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "udon!"
   },

--- a/plugins/pm-guard/hooks/check-pm.sh
+++ b/plugins/pm-guard/hooks/check-pm.sh
@@ -57,11 +57,14 @@ if [ -z "$allowed_pm" ]; then
   fi
 fi
 
-# Cannot determine PM → warn and allow
+# Cannot determine PM → only warn if command contains a PM keyword
 if [ -z "$allowed_pm" ]; then
-  cat <<'EOF'
+  all_pm_cmds="npm|npx|yarn|pnpm|pnpx|bun|bunx|deno"
+  if printf '%s' "$command" | grep -qE "(^|[^a-zA-Z0-9_.-])(${all_pm_cmds})([^a-zA-Z0-9_./-]|$)"; then
+    cat <<'EOF'
 {"systemMessage":"pm-guard: Could not detect the project's package manager. Set PM_GUARD_ALLOWED env var, add packageManager to package.json, or ensure a lockfile exists."}
 EOF
+  fi
   exit 0
 fi
 

--- a/tests/check-pm.bats
+++ b/tests/check-pm.bats
@@ -212,9 +212,14 @@ teardown() {
 # E: No PM Detected -- systemMessage Warning
 # =============================================================================
 
-@test "no-pm: warns when no detection method succeeds" {
+@test "no-pm: warns when PM command is used but no detection method succeeds" {
   run_hook --dir "$TEST_TEMP_DIR" "npm install"
   assert_warning
+}
+
+@test "no-pm: silent when command has no PM keywords" {
+  run_hook --dir "$TEST_TEMP_DIR" "git status"
+  assert_allowed
 }
 
 @test "no-pm: command is still allowed (exit 0)" {


### PR DESCRIPTION
## Summary

PM 未検出時のフォールバック警告を、PM キーワードを含むコマンドのみに限定する。`git status` 等の無関係なコマンドでは警告を出さない。

Closes #3

## Changes

- `check-pm.sh`: `allowed_pm` 未検出時、コマンドに PM キーワード (npm/yarn/pnpm/bun/deno 等) が含まれる場合のみ `systemMessage` を出力するよう変更
- `check-pm.bats`: 非 PM コマンドで警告が出ないことを検証するテストを追加
- `CLAUDE.md`: 動作説明を更新
- bump plugin version to 1.1.1
